### PR TITLE
Fixme fixes

### DIFF
--- a/grading/execute.cpp
+++ b/grading/execute.cpp
@@ -376,13 +376,16 @@ int exec_this_command(const std::string &cmd, int SECCOMP_ENABLED, std::ofstream
   parse_command_line(cmd, my_program, my_args, my_stdin, my_stdout, my_stderr, logfile);
 
 
-  char** const my_char_args = new char * [my_args.size()+2];  // yes, there is a memory leak here
-  my_char_args[0] = (char*) my_program.c_str();
+  char** temp_args = new char* [my_args.size()+2];
+  temp_args[0] = (char*) my_program.c_str();
   for (int i = 0; i < my_args.size(); i++) {
     std::cout << "'" << my_args[i] << "' ";
-    my_char_args[i+1] = (char*) my_args[i].c_str();
+    temp_args[i+1] = (char*) my_args[i].c_str();
   }
-  my_char_args[my_args.size()+1] = (char *)NULL;  // FIXME: casting away the const :(
+  my_char_args[my_args.size()+1] = (char *)NULL;
+
+  char** const my_char_args = temp_args;
+
   std::cout << std::endl << std::endl;
 
 

--- a/grading/execute.cpp
+++ b/grading/execute.cpp
@@ -376,7 +376,7 @@ int exec_this_command(const std::string &cmd, int SECCOMP_ENABLED, std::ofstream
   parse_command_line(cmd, my_program, my_args, my_stdin, my_stdout, my_stderr, logfile);
 
 
-  char** temp_args = new char* [my_args.size()+2];
+  char** temp_args = new char* [my_args.size()+2];   //memory leak here
   temp_args[0] = (char*) my_program.c_str();
   for (int i = 0; i < my_args.size(); i++) {
     std::cout << "'" << my_args[i] << "' ";


### PR DESCRIPTION
Used a temporary variable so that the my_char_args const, neccessary for later execv call, wasn't being ignored and casted away.

Please check this to make sure it works, I can't test it because the grading code doesn't work.