### PR TITLE
Content display

### DIFF
--- a/public/controller/data_functions.php
+++ b/public/controller/data_functions.php
@@ -486,7 +486,7 @@ function is_valid_semester($semester) {
         return true;
     }
     //For auto-setup script:
-    //if ($semester == "default") {return true;}
+    //if ($semester == "s15") {return true;}
     return false;
 }
 
@@ -512,7 +512,7 @@ function is_valid_course($course) {
         return true;
     }
     //For auto-setup script:
-    //if ($course == "default") {return true;}
+    //if ($course == "csci1200") {return true;}
     return false;
 }
 
@@ -768,7 +768,6 @@ function get_assignment_results($username, $semester,$course, $assignment_id, $a
     }
     return $tmp;
 }
-
 
 //Get list of student-submitted files that students are allowed to view
 function get_files_to_view($class_config,$semester,$course,$assignment_id, $username,$assignment_version){

--- a/public/controller/data_functions.php
+++ b/public/controller/data_functions.php
@@ -770,6 +770,44 @@ function get_assignment_results($username, $semester,$course, $assignment_id, $a
 }
 
 
+//Get list of student-submitted files that students are allowed to view
+function get_files_to_view($class_config,$semester,$course,$assignment_id, $username,$assignment_version){
+    $assignments            = $class_config["assignments"];
+    $list_with_wildcards    = array();
+    $result                 = array();
+
+    //Grab files_to_view from current assignment id
+    foreach ($assignments as $one) {
+        if (isset($one["assignment_id"]) && $one["assignment_id"] == $assignment_id){
+            if (isset($one["files_to_view"]) ){
+                $list_with_wildcards =  $one["files_to_view"];
+                break;
+            }
+            else 
+                return $result;
+        }
+    }
+
+
+    //Get absolute path to the directory that contains student's submitted files
+    $path_front = get_path_front_course($semester,$course);
+    $folder = $path_front."/submissions/".$assignment_id."/".$username."/".$assignment_version."/";
+
+    //Store all the files that match with each pattern in list_with_wildcards
+    foreach ($list_with_wildcards as $pattern){
+        foreach (glob($folder.$pattern) as $file){
+            if (!in_array($file, $result)){
+                array_push($result, substr($file, strlen($folder)) );
+            }
+        }
+    }
+
+    return $result;
+
+}
+
+
+
 // FROM http://www.php.net/manual/en/function.json-decode.php
 function removeTrailingCommas($json){
     $json=preg_replace('/,\s*([\]}])/m', '$1', $json);

--- a/public/controller/homework.php
+++ b/public/controller/homework.php
@@ -59,17 +59,16 @@ $assignment_version_in_grading_queue = version_in_grading_queue($username, $seme
 
 $points_visible =            $assignment_config["points_visible"];
 
+
+//List of submitted files that server is allowed to display
+$files_to_view =            get_files_to_view($class_config,$semester,$course,$assignment_id, $username,$assignment_version);
+
+
 if (isset($class_config["download_files"])){
     $download_files = $class_config["download_files"];
 }
 else{
     $download_files = false;
-}
-if (isset($class_config["download_readme"])){
-    $download_readme = $class_config["download_readme"];
-}
-else{
-    $download_readme = false;
 }
 if (isset($class_config["grade_summary"])){
     $grade_summary = $class_config["grade_summary"];
@@ -101,7 +100,6 @@ render("homework", array(
     "view_points"=>             $view_points,
     "view_hidden_points"=>      $view_hidden_points,
     "download_files"=>          $download_files,
-    "download_readme"=>         $download_readme,
     "grade_summary"=>           $grade_summary,
     "ta_grades"=>               $ta_grades,
       // added for debugging
@@ -119,7 +117,9 @@ render("homework", array(
     "assignment_message"=>      $assignment_message,
     "submitting_version_in_grading_queue"=>$submitting_version_in_grading_queue,
     "assignment_version_in_grading_queue"=>$assignment_version_in_grading_queue,
-    "status"=>                  $status
+    "status"=>                  $status,
+
+    "files_to_view"=>           $files_to_view
     )
 );
 ?>

--- a/public/index.php
+++ b/public/index.php
@@ -16,7 +16,7 @@ if (isset($_SERVER['PHP_AUTH_USER'])) {
 } else {
     // if not already authenticated do it
     //
-    echo 'Internal Error - Not Authenticated'; exit();//here
+    if (!isset($_SERVER['PHP_AUTH_USER'])) {header('WWW-Authenticate: Basic realm=HWServer'); header('HTTP/1.0 401 Unauthorized'); exit;} else { $user = $_SERVER['PHP_AUTH_USER'];}
     //
 }
 

--- a/public/resources/badge.css
+++ b/public/resources/badge.css
@@ -298,3 +298,29 @@
 #HWsubmission .red-background {
     background-color: #c00000;
 }
+
+#HWsubmission .file-display{
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-top: 7.5px;
+    padding-bottom: 7.5px;
+
+    box-sizing: border-box;
+
+    /*vertical-align: top;*/
+    /*word-wrap: break-word*/
+    /*overflow:hidden;*/
+
+    width: 100%;
+    overflow-x:auto;
+
+    font-family: "Lucida Console", Monaco, monospace;
+
+    /* Unselectable text */
+    -moz-user-select: none; 
+    -khtml-user-select: none; 
+    -webkit-user-select: none; 
+    -o-user-select: none;
+
+}
+

--- a/public/view/filecontent_display.php
+++ b/public/view/filecontent_display.php
@@ -1,0 +1,102 @@
+<!-- DETAILS ON SUBMITTED FILES -->
+<div class="row sub-text">
+    <h4>Submitted Files:
+        <?php
+            if (isset($download_files) && $download_files == true){
+                echo '<a class = "view_file"  href="?page=viewfile&semester='.$semester.'&course='.$course.'&assignment_id='.$assignment_id.'&assignment_version='.$assignment_version.'&file_name=all">Download All (as zip)</a>';
+            }
+        ?>
+    </h4>
+    <?php
+    echo '<div class="box">';
+
+          //keep track of number of file-display blocks 
+          $counter = 0;
+
+          foreach($submitted_files as $file) {
+              if ($file === end($submitted_files)){
+                  echo '<div>';
+              }
+              else{
+                  echo '<div style="border-bottom: 1px solid #dddddd;">';
+              }
+            
+                //name and size of the file ( ex. "code1.cpp (3kb)" )
+                $file_desc = $file["name"].' ('.$file["size"].'kb)';
+      
+                echo '<p class="file-header"'; 
+
+                    //does files_to_view exist in class.json and can this file be displayed?
+                    if (isset($files_to_view) && in_array($file["name"], $files_to_view)){
+                        //extend the file-header class to listen to user clicks so that it expands
+                        //and display the file contents
+
+                        echo 'href="#" onclick="return toggleDiv('."'".'filedisplay_'.$counter."'".');" style="cursor:pointer;" >'.$file_desc.'<a class = "view_file" href="#">View</a>';
+                        
+                        //is this file also downloadable and does download_file exist in class.json
+                        if ( (isset($download_files) && $download_files == true) ){
+                            //create link to download page
+                            echo '<a class = "view_file" href="?page=viewfile&semester='.$semester.'&course='.$course.'&assignment_id='.$assignment_id.'&assignment_version='.$assignment_version.'&file_name='.$file["name"].'">Download</a>';
+                        }
+
+                        ?>
+
+                        <!-- create the outermost div that will appear if display is set to "block" -->
+                        <div id="filedisplay_<?php echo $counter ?>" class="diff-block" style="display:block">
+
+                            <div class="file-display">
+
+                                <?php 
+                                $frontpath = get_path_front_course($semester,$course);;
+                                $file_path = $frontpath.'/submissions/'.$assignment_id.'/'.$username.'/'.$assignment_version.'/'.$file["name"];
+                                $file_open = fopen($file_path,"r") or die("Unable to open file!");
+
+                                //is there content in this file?
+                                if (filesize($file_path) == 0){
+                                    //display warning message
+                                    echo "<font color='red'>".$file["name"]." is empty!</font>";
+                                }
+                                else {
+                                    //read the file line-by-line
+                                    while (!feof($file_open)){
+                                        echo htmlentities(fgets($file_open))."<br>";
+                                    }
+                                }
+
+                                fclose($file_open);
+                                ?> 
+
+                            </div>
+
+                        </div>
+
+                        <script> 
+                            //close all the filedisplay blocks
+                            toggleDiv('filedisplay_'+<?php echo $counter ?>);
+                        </script>
+
+
+
+                        <?php
+
+                        $counter = $counter + 1;
+
+                    }
+
+                    //does download_files exist in class.json and can files be downloaded
+                    else if (isset($download_files) && $download_files == true){
+                        //close off file-header tag immediately and create a link to download page
+                        echo '>'.$file_desc.'<a class = "view_file" href="?page=viewfile&semester='.$semester.'&course='.$course.'&assignment_id='.$assignment_id.'&assignment_version='.$assignment_version.'&file_name='.$file["name"].'">Download</a>';
+                    }
+                    else{
+                        //close off file-header tag
+                        echo '>'.$file_desc; 
+                    }
+
+                echo '</p>';
+                echo '</div>';
+            }
+        echo '</div>';
+
+    ?>
+</div>

--- a/public/view/filecontent_display.php
+++ b/public/view/filecontent_display.php
@@ -58,9 +58,12 @@
                                 }
                                 else {
                                     //read the file line-by-line
+				    //use <pre> tag to support multi-space and tabbed sentences
+                                    echo "<pre>";
                                     while (!feof($file_open)){
-                                        echo htmlentities(fgets($file_open))."<br>";
+                                        echo htmlentities(fgets($file_open));
                                     }
+                                    echo "</pre>";
                                 }
 
                                 fclose($file_open);

--- a/public/view/homework.php
+++ b/public/view/homework.php
@@ -210,39 +210,23 @@ window.addEventListener('load', function() {
                     //$date_submitted = get_submission_time($user,$semester,$course,$assignment_id,$assignment_version);
                     //echo "<p><b>Date Submitted = ".$date_submitted."</b></p>";
                     ?> -->
-                    <!-- SUBMITTED FILES -->
-                    <div class="row sub-text">
-                        <h4>Submitted Files:
-                            <?php
-                                if (isset($download_files) && $download_files == true){
-                                    echo '<a class = "view_file"  href="?page=viewfile&semester='.$semester.'&course='.$course.'&assignment_id='.$assignment_id.'&assignment_version='.$assignment_version.'&file_name=all">Download All (as zip)</a>';
-                                }
-                            ?>
-                        </h4>
-                        <?php
-                        echo '<div class="box">';
-                              foreach($submitted_files as $file) {
-                                  if ($file === end($submitted_files)){
-                                      echo '<div>';
-                                  }
-                                  else{
-                                      echo '<div style="border-bottom: 1px solid #dddddd;">';
-                                  }
-                                    echo '<p class="file-header">'.$file["name"].' ('.$file["size"].'kb)';
-                                        if (isset($download_files) && $download_files == true){
-                                            echo '<a class = "view_file" href="?page=viewfile&semester='.$semester.'&course='.$course.'&assignment_id='.$assignment_id.'&assignment_version='.$assignment_version.'&file_name='.$file["name"].'">Download</a>';
-                                        }
-                                        else if (isset($download_readme) && $download_readme == true && strtolower($file["name"]) == "readme.txt"){
-                                            echo '<a class = "view_file" href="?page=viewfile&semester='.$semester.'&course='.$course.'&assignment_id='.$assignment_id.'&assignment_version='.$assignment_version.'&file_name='.$file["name"].'">Download</a>';
-                                        }
-                                    echo '</p>';
-                                    echo '</div>';
-                                }
-                            echo '</div>';
+                   <?php
 
-                        ?>
-                    </div>
-                    <?php
+                    //Box with name, size, and content of submitted files
+                    render("filecontent_display",array(
+                        "download_files"=>$download_files,
+                        "submitted_files"=>$submitted_files,
+                        "semester"=>$semester,
+                        "course"=>$course,
+                        "username"=>$username,
+                        "assignment_id"=>$assignment_id,
+                        "assignment_version"=>$assignment_version,
+                        "files_to_view"=>$files_to_view
+                        ));
+
+                    
+
+
                     if ($assignment_version_in_grading_queue) {
                     ?>
                         <span>Version <?php echo $assignment_version;?> is currently being graded.</span>


### PR DESCRIPTION
Created a pop-up viewer for submitted files. 
To use this feature, go to the class.json file for any course, add a new variable labeled "files_to_view" in an assignment, and then assign it to an array of wildcard patterns that matches the files you want others to view. Sorry if my wording is a bit off, here's an example:
````
     "assignments": [
        {
            "assignment_id":"hw1",
            "assignment_name":"Homework 1",
            "released":false,
            "ta_grade_released":false,
            "files_to_view":[ "*.cpp" , "*.txt" ]
        },
````
So in this example, only files that end with .txt or .cpp can be displayed with its contents. Under "Submitted Files" box, a button called "View" should appear to the right of the file name. 