### PR TITLE
Issue 290

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 # Default to lf for Ubuntu Linux
-* text=lf
+* text eol=lf
 
 # Explicitly declare text files you want to always be normalized and converted
 # to native line endings on checkout.
@@ -24,7 +24,6 @@
 *.yaml text
 Vagrantfile text
 setcsvfields text
-
 
 # Declare files that will always have CRLF line endings on checkout.
 # NONE


### PR DESCRIPTION
Corrected `text` attribute in `.gitattributes`.  Unfortunately, adequate testing in Windows environment requires merging with master, so that local `core.autocrlf` rule is overridden.