### PR TITLE
replace != with !== in csrf checks

### DIFF
--- a/TAGradingServer/account/ajax/account-labs.php
+++ b/TAGradingServer/account/ajax/account-labs.php
@@ -1,7 +1,7 @@
 <?php
 include "../../toolbox/functions.php";
 
-if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf']) {
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf']) {
     exit("invalid csrf token");
 }
 

--- a/TAGradingServer/account/ajax/account-other.php
+++ b/TAGradingServer/account/ajax/account-other.php
@@ -1,7 +1,7 @@
 <?php
 include "../../toolbox/functions.php";
 
-if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf']) {
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf']) {
     die("invalid csrf token");
 }
 

--- a/TAGradingServer/account/ajax/account-tests.php
+++ b/TAGradingServer/account/ajax/account-tests.php
@@ -1,7 +1,7 @@
 <?php
 include "../../toolbox/functions.php";
 
-if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf']) {
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf']) {
     die("invalid csrf token");
 }
 

--- a/TAGradingServer/account/ajax/admin-csv-report.php
+++ b/TAGradingServer/account/ajax/admin-csv-report.php
@@ -4,7 +4,7 @@ include  "../../toolbox/functions.php";
 
 check_administrator();
 
-if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf']) {
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf']) {
     die("invalid csrf token");
 }
 

--- a/TAGradingServer/account/ajax/admin-hw-report.php
+++ b/TAGradingServer/account/ajax/admin-hw-report.php
@@ -6,7 +6,7 @@ use lib\Database;
 
 check_administrator();
 
-if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf']) {
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf']) {
     die("invalid csrf token");
 }
 

--- a/TAGradingServer/account/ajax/admin-labs.php
+++ b/TAGradingServer/account/ajax/admin-labs.php
@@ -6,7 +6,7 @@ check_administrator();
 
 $action = $_GET['action'];
 
-if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf']) {
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf']) {
     exit("invalid csrf token");
 }
 

--- a/TAGradingServer/account/ajax/admin-other.php
+++ b/TAGradingServer/account/ajax/admin-other.php
@@ -4,7 +4,7 @@ include "../../toolbox/functions.php";
 
 check_administrator();
 
-if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf']) {
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf']) {
     die("invalid csrf token");
 }
 

--- a/TAGradingServer/account/ajax/admin-rubrics.php
+++ b/TAGradingServer/account/ajax/admin-rubrics.php
@@ -4,7 +4,7 @@ include "../../toolbox/functions.php";
 
 check_administrator();
 
-if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf']) {
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf']) {
     die("invalid csrf token");
 }
 

--- a/TAGradingServer/account/ajax/admin-tests.php
+++ b/TAGradingServer/account/ajax/admin-tests.php
@@ -4,7 +4,7 @@ include "../../toolbox/functions.php";
 
 check_administrator();
 
-if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf']) {
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf']) {
     die("invalid csrf token");
 }
 $action = $_GET['action'];

--- a/TAGradingServer/account/submit/account-rubric.php
+++ b/TAGradingServer/account/submit/account-rubric.php
@@ -2,7 +2,7 @@
 
 include "../../toolbox/functions.php";
 
-if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf']) {
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf']) {
     die("invalid csrf token");
 }
 

--- a/TAGradingServer/account/submit/admin-classlist.php
+++ b/TAGradingServer/account/submit/admin-classlist.php
@@ -82,7 +82,7 @@ if (isset($_GET['xlsx2csv']) && $_GET['xlsx2csv'] == 1) {
 	}
 }
 
-if (!isset($_SESSION['post']['csrf_token']) || $_SESSION['post']['csrf_token'] != $_SESSION['csrf']) {
+if (!isset($_SESSION['post']['csrf_token']) || $_SESSION['post']['csrf_token'] !== $_SESSION['csrf']) {
 	die("invalid csrf token");
 }
 

--- a/TAGradingServer/account/submit/admin-config.php
+++ b/TAGradingServer/account/submit/admin-config.php
@@ -5,7 +5,7 @@ use \lib\Database;
 
 check_administrator();
 
-if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf']) {
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf']) {
     die("invalid csrf token");
 }
 

--- a/TAGradingServer/account/submit/admin-grade-summaries.php
+++ b/TAGradingServer/account/submit/admin-grade-summaries.php
@@ -4,7 +4,7 @@ require "../../toolbox/functions.php";
 
 check_administrator();
 
-if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf']) {
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf']) {
     die("invalid csrf token");
 }
 

--- a/TAGradingServer/account/submit/admin-grading-sections.php
+++ b/TAGradingServer/account/submit/admin-grading-sections.php
@@ -4,7 +4,7 @@ require_once "../../toolbox/functions.php";
 
 check_administrator();
 
-if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf']) {
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf']) {
     die("invalid csrf token");
 }
 

--- a/TAGradingServer/account/submit/admin-rubric.php
+++ b/TAGradingServer/account/submit/admin-rubric.php
@@ -4,7 +4,7 @@ include "../../toolbox/functions.php";
 
 check_administrator();
 
-if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf']) {
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf']) {
     die("invalid csrf token");
 }
 

--- a/public/controller/update.php
+++ b/public/controller/update.php
@@ -17,7 +17,7 @@ if (!can_edit_assignment($_SESSION["id"], $semester, $course, $assignment_id, $a
    header ("Location: index.php?semester=".$semester."&course=".$course."&assignment_id=".$assignment_id."&assignment_version=".$assignment_version);
    exit();
 }
-if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf']) {
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf']) {
    $_SESSION['status'] = "invalid_token";
    header ("Location: index.php?semester=".$semester."&course=".$course."&assignment_id=".$assignment_id."&assignment_version=".$assignment_version);
    exit();

--- a/public/controller/upload.php
+++ b/public/controller/upload.php
@@ -8,7 +8,7 @@ $class_config=check_class_config($semester,$course);
 $dev_team=$class_config["dev_team"];
 $assignment_id=check_assignment_id($class_config);
 
-if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf']) {
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf']) {
   $_SESSION['status'] = 'invalid_token';
   header("Location: index.php?page=displaymessage&semester=".$semester."&course=".$course."&assignment_id=".$assignment_id);
 }


### PR DESCRIPTION
Change suggested by Toshi.
!= casts to same type and might lead to unexpected results.
