### PR TITLE
allow for a host to connect to guest postgresql server

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -49,6 +49,8 @@ if [ ${VAGRANT} == 1 ]; then
 ##    https://192.168.56.102 (svn)                        ##
 ##    https://192.168.56.103 (grading)                    ##
 ##                                                        ##
+##  The database can be accessed via localhost:15432      ##
+##                                                        ##
 ##  Happy developing!                                     ##
 ############################################################
 ' > /etc/motd
@@ -334,6 +336,12 @@ if [ ${VAGRANT} == 1 ]; then
 	echo "Creating PostgreSQL users"
 	su postgres -c "source ${HWSERVER_DIR}/.setup/db_users.sh";
 	echo "Finished creating PostgreSQL users"
+
+    echo "Setting up Postgres to connect to via host"
+    PG_VERSION="$(psql -V | egrep -o '[0-9]{1,}\.[0-9]{1,}')"
+	sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/" "/etc/postgresql/${PG_VERSION}/main/postgresql.conf"
+	echo "host    all             all             all                     md5" >> "/etc/postgresql/${PG_VERSION}/main/pg_hba.conf"
+	service postgresql restart
 fi
 
 #################################################################

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,4 +19,6 @@ Vagrant.configure(2) do |config|
     s.path = ".setup/vagrant.sh"
     s.args = ["vagrant"]
   end
+
+  config.vm.network "forwarded_port", guest: 5432, host: 15432
 end


### PR DESCRIPTION
This allows a user to use psql or pgAdmin3 on their host to connect to the VM's postgresql server allowing for easier time running queries/modifying tables/etc than having to do everything through an ssh session.